### PR TITLE
Example: Extract user from token inside service is bad practice

### DIFF
--- a/src/Example/BadPractice/Command.php
+++ b/src/Example/BadPractice/Command.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example\BadPractice;
+
+use App\Example\User;
+
+final class Command
+{
+    public function __construct(private SmsService $smsService)
+    {
+    }
+
+    // Предположим нам надо отправить смс юзерам из эксель таблицы, в которой есть телефоны
+    public function run()
+    {
+        $users = $this->extractUsersFromExcelFile();
+
+        // Внутри попытаемся вытащить токен, которого не бывает в команде
+        // Мы не сможем отправить одному юзеру, не говоря уже о нескольких
+        $this->smsService->sendMessage('some-message');
+    }
+
+    private function extractUsersFromExcelFile(): array
+    {
+        return [
+            new User(1, '+79998887766'),
+            new User(2, '+70001112233'),
+            new User(3, '+70001112244'),
+        ];
+    }
+}

--- a/src/Example/BadPractice/Controller.php
+++ b/src/Example/BadPractice/Controller.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example\BadPractice;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[AsController]
+final class Controller
+{
+    public function __construct(private SmsService $smsService)
+    {
+    }
+
+    #[Route(path: '/api/sms', methods: 'POST')]
+    public function sendSms(): Response
+    {
+        $this->smsService->sendMessage('some sms message');
+
+        return new Response("Sms sended");
+    }
+}

--- a/src/Example/BadPractice/SmsService.php
+++ b/src/Example/BadPractice/SmsService.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example\BadPractice;
+
+use App\Example\SmsSenderApi;
+use App\Example\User;
+use Exception;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class SmsService
+{
+    public function __construct(private TokenStorageInterface $tokenStorage, private SmsSenderApi $smsSenderApi)
+    {
+    }
+
+    public function sendMessage(string $message): void
+    {
+        /** @var $user User */
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if ($user === null) {
+            throw new Exception('User does not exist in token storage');
+        }
+
+        $this->smsSenderApi->sendSms($user->phone(), $message);
+    }
+}

--- a/src/Example/BestPractice/Command.php
+++ b/src/Example/BestPractice/Command.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example\BestPractice;
+
+use App\Example\User;
+
+final class Command
+{
+    public function __construct(private SmsService $smsService)
+    {
+    }
+
+    // Предположим нам надо отправить смс юзерам из эксель таблицы, в которой есть телефоны
+    public function run()
+    {
+        $users = $this->extractUsersFromExcelFile();
+
+        // Тут всё Ок, т.к. нет скрытого состояния с вытаскиванием юзера из токена внутри smsService
+        foreach ($users as $user) {
+            $this->smsService->sendMessage($user->phone(), 'some-message');
+        }
+    }
+
+    private function extractUsersFromExcelFile(): array
+    {
+        return [
+            new User(1, '+79998887766'),
+            new User(2, '+70001112233'),
+            new User(3, '+70001112244'),
+        ];
+    }
+}

--- a/src/Example/BestPractice/Controller.php
+++ b/src/Example/BestPractice/Controller.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example\BestPractice;
+
+use App\Example\User;
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+#[AsController]
+final class Controller
+{
+    public function __construct(private SmsService $smsService, private TokenStorageInterface $tokenStorage)
+    {
+    }
+
+    #[Route(path: '/api/sms', methods: 'POST')]
+    public function sendSms(): Response
+    {
+        /** @var User $user */
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if ($user === null) {
+            throw new Exception('User does not exist in token storage');
+        }
+
+        $this->smsService->sendMessage($user->phone(), 'some-message from request');
+
+        return new Response("Sms sended");
+    }
+}

--- a/src/Example/BestPractice/SmsService.php
+++ b/src/Example/BestPractice/SmsService.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example\BestPractice;
+
+use App\Example\SmsSenderApi;
+
+final class SmsService
+{
+    public function __construct(private SmsSenderApi $smsSenderApi)
+    {
+    }
+
+    public function sendMessage(string $phone, string $message): void
+    {
+        $this->smsSenderApi->sendSms($phone, $message);
+    }
+}

--- a/src/Example/SmsSenderApi.php
+++ b/src/Example/SmsSenderApi.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example;
+
+interface SmsSenderApi
+{
+    public function sendSms(string $phone, string $message): void;
+}

--- a/src/Example/User.php
+++ b/src/Example/User.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Example;
+
+
+final class User
+{
+    public function __construct(private int $id, private string $phone)
+    {
+    }
+
+    public function id(): int
+    {
+        return $this->id;
+    }
+
+    public function phone(): string
+    {
+        return $this->phone;
+    }
+}


### PR DESCRIPTION
Пример, почему вытаскивать юзера из токена в сервисе это плохая практика.
Предположим есть сервис для отправки смс сообщение, `SmsService`.
Сначала мы хотели отправлять смс с помощью HTTP request через контроллер.
Через какое-то время захотели отправлять смс по юзерам из эксель файлов, для этого создали команду для импорта.
Структура неймспейса `Example`:
- `BadPractice` - пример как делать не надо
   - `Command` - тут команда даже не может быть выполнена без изменений в `SmsService`
   - `Controller`
   - `SmsService`
 - `BestPractice` - хорошая практика, тут для отправки смс из команды не надо делать никаких изменений в `SmsService`
   - `Command` 
   - `Controller`
   - `SmsService`
- `User` - юзер имплементирующий `UserInterface`(опустил это)
- `SmsSenderApi` - интеграция с смс провайдером

Обсуждение:
https://t.me/symfoniacs_store/211